### PR TITLE
refa: rename extconfig to config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,7 +1,8 @@
-// SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2022 Steadybit GmbH
+/*
+ * Copyright 2023 steadybit GmbH. All rights reserved.
+ */
 
-package extconfig
+package config
 
 import (
 	"github.com/kelseyhightower/envconfig"

--- a/extrobots/discovery.go
+++ b/extrobots/discovery.go
@@ -9,7 +9,7 @@ import (
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/exthttp"
 	"github.com/steadybit/extension-kit/extutil"
-	"github.com/steadybit/extension-scaffold/extconfig"
+	"github.com/steadybit/extension-scaffold/config"
 	"net/http"
 )
 
@@ -99,9 +99,9 @@ func getAttributeDescriptions() discovery_kit_api.AttributeDescriptions {
 	}
 }
 
-func getDiscoveredTargets(w http.ResponseWriter, r *http.Request, _ []byte) {
-	targets := make([]discovery_kit_api.Target, len(extconfig.Config.RobotNames))
-	for i, name := range extconfig.Config.RobotNames {
+func getDiscoveredTargets(w http.ResponseWriter, _ *http.Request, _ []byte) {
+	targets := make([]discovery_kit_api.Target, len(config.Config.RobotNames))
+	for i, name := range config.Config.RobotNames {
 		targets[i] = discovery_kit_api.Target{
 			Id:         name,
 			TargetType: targetID,

--- a/main.go
+++ b/main.go
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2023 steadybit GmbH. All rights reserved.
+ */
+
 package main
 
 import (
@@ -7,7 +11,7 @@ import (
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/exthttp"
 	"github.com/steadybit/extension-kit/extlogging"
-	"github.com/steadybit/extension-scaffold/extconfig"
+	"github.com/steadybit/extension-scaffold/config"
 	"github.com/steadybit/extension-scaffold/extevents"
 	"github.com/steadybit/extension-scaffold/extrobots"
 )
@@ -28,8 +32,8 @@ func main() {
 
 	// Most extensions require some form of configuration. These calls exist to parse and validate the
 	// configuration obtained from environment variables.
-	extconfig.ParseConfiguration()
-	extconfig.ValidateConfiguration()
+	config.ParseConfiguration()
+	config.ValidateConfiguration()
 
 	// This call registers a handler for the extension's root path. This is the path initially accessed
 	// by the Steadybit agent to obtain the extension's capabilities.


### PR DESCRIPTION
As the config package doesn't implement any extension point I'd suggest that we rename it to config.
This also reads a bit more nicely when using it and also alignes the scaffold with the other extensions already implemented.