### PR TITLE
feat: weekly Monday auto patch-release workflow

### DIFF
--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -1,0 +1,26 @@
+name: Monday Auto Patch Release
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: If true, evaluate without committing or notifying Slack
+        type: boolean
+        default: true
+      force_release:
+        description: If true, release even when the commit range contains unsafe commits
+        type: boolean
+        default: false
+
+jobs:
+  auto-patch-release:
+    uses: steadybit/extension-kit/.github/workflows/reusable-auto-patch-release.yml@main # NOSONAR githubactions:S7637 - our own action
+    with:
+      VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
+      dry_run: ${{ inputs.dry_run || false }}
+      force_release: ${{ inputs.force_release || false }}
+    secrets:
+      VERSION_BUMPER_SECRET: ${{ secrets.GH_APP_STEADYBIT_PRIVATE_KEY }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-patch-release.yml`, a tiny caller that runs every Monday at 06:00 UTC and delegates to the new `steadybit/extension-kit` reusable workflow.
- Wires the existing `GH_APP_STEADYBIT_*` (used by the helm chart bumper) and `SLACK_WEBHOOK_URL` secrets.
- Manual `workflow_dispatch` defaults to `dry_run=true` to make exploratory runs safe.

**Depends on** [steadybit/extension-kit#125](https://github.com/steadybit/extension-kit/pull/125) — please merge that first. The `@main` reference here won't resolve until it lands.

This repo is the sandbox for proving the workflow before rolling it out to the rest of the extensions.

## Test plan

- [ ] Merge extension-kit#125 first.
- [ ] Merge this PR.
- [ ] Trigger via Actions → "Monday Auto Patch Release" → Run workflow → `dry_run=true`.
- [ ] Verify the printed evaluation: latest version tag detected correctly, each commit classified, no Slack message sent.
- [ ] Trigger again with `dry_run=false` and verify a `:rocket:` lands in `#sig-development` (or `:no_entry_sign:` if commits aren't safe).
- [ ] If a real release is cut, verify the existing `ci.yml` fires on the tag push and goreleaser completes.