### PR TITLE
feat: drop Monday from workflow name and add release_type input

### DIFF
--- a/.github/workflows/auto-patch-release.yml
+++ b/.github/workflows/auto-patch-release.yml
@@ -1,4 +1,4 @@
-name: Monday Auto Patch Release
+name: Auto Patch Release
 
 on:
   schedule:
@@ -13,6 +13,14 @@ on:
         description: If true, release even when the commit range contains unsafe commits
         type: boolean
         default: false
+      release_type:
+        description: Which component of the version to bump
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
 
 jobs:
   auto-patch-release:
@@ -21,6 +29,7 @@ jobs:
       VERSION_BUMPER_APPID: ${{ vars.GH_APP_STEADYBIT_APP_ID }}
       dry_run: ${{ inputs.dry_run || false }}
       force_release: ${{ inputs.force_release || false }}
+      release_type: ${{ inputs.release_type || 'patch' }}
     secrets:
       VERSION_BUMPER_SECRET: ${{ secrets.GH_APP_STEADYBIT_PRIVATE_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Caller-side follow-ups to extension-kit#126.

- **Workflow renamed** from "Monday Auto Patch Release" to "Auto Patch Release" — the schedule is internal detail; this also keeps the label honest on non-Monday manual runs.
- **`release_type` workflow_dispatch input** (choice: `patch | minor | major`, default `patch`) plumbed through to the reusable. Scheduled runs continue to use the default.

**Depends on** [steadybit/extension-kit#126](https://github.com/steadybit/extension-kit/pull/126) — merge that first so the new `release_type` reusable input resolves.

## Test plan

- [ ] Merge extension-kit#126 first.
- [ ] Merge this PR.
- [ ] Trigger via Actions → "Auto Patch Release" → Run workflow with `release_type=minor`, `force_release=true`, `dry_run=true`.
- [ ] Verify the run is labeled "Force minor release" and previews the correct next minor version.